### PR TITLE
Fix Argument grouping & builder pattern code

### DIFF
--- a/code-snippets/src/bin/grouping_and_builder_pattern_clap.rs
+++ b/code-snippets/src/bin/grouping_and_builder_pattern_clap.rs
@@ -45,10 +45,9 @@ fn main() {
         None => &0,
     };
 
-    if matches.index_of("cube") == Some(3){
+    if let Some(true) = matches.get_one("cube") {
         println!("Cube of {} is: {}", no, no * no * no);
-    }
-    else if matches.index_of("square") == Some(3){
+    } else if let Some(true) = matches.get_one("square") {
         println!("Square of {} is: {}", no, no * no);
     }
 }

--- a/code-snippets/src/bin/grouping_and_builder_pattern_clap.rs
+++ b/code-snippets/src/bin/grouping_and_builder_pattern_clap.rs
@@ -2,7 +2,6 @@
     A CLI application showing
         - grouping of command-line arguments
 */
-
 use clap::{Command, Arg, ArgGroup};
 
 fn main() {
@@ -38,16 +37,14 @@ fn main() {
 
     // Runtime argument parsing
     let matches = cmd.get_matches();
-    let number = matches.get_one("number");
-
-    let no = match number {
-        Some(number) => number,
+    let number_passed = matches.get_one("number");
+    let number = match number_passed {
+        Some(number_passed) => number_passed,
         None => &0,
     };
-
     if let Some(true) = matches.get_one("cube") {
-        println!("Cube of {} is: {}", no, no * no * no);
+        println!("Cube of {} is: {}", number, number * number * number);
     } else if let Some(true) = matches.get_one("square") {
-        println!("Square of {} is: {}", no, no * no);
+        println!("Square of {} is: {}", number, number * number);
     }
 }


### PR DESCRIPTION
Fixed code so as to not use index position to get the argument passed in Argument_Grouping code.